### PR TITLE
Cuckoo APIの追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -151,4 +151,11 @@ if __name__ == '__main__':
         app.config['cuckoo'] = True
     except:
         app.config['cuckoo'] = False
+    
+    try:
+        subprocess.Popen(['cuckoo','api','--host','0.0.0.0'])
+        app.config['cuckoo_api'] = True
+    except:
+        app.config['cuckoo_api'] = False
+    
     app.run(host='0.0.0.0', port=5000)

--- a/templates/file.html
+++ b/templates/file.html
@@ -6,7 +6,16 @@
         {% if k != '_id' %}
         <tr>
             <th scope="row"> {{ k }} </th>
-            <th> {%if k == 'VirusTotalLink' %}<a href="{{ v }}">{{ v }}</a>{% elif k == 'nearest sha256' %}<a href="/file/{{ v }}">{{ v }}</a>{% else %}<pre>{{ v }}</pre>{% endif %} </th>
+            <th> {%if k == 'VirusTotalLink' %}
+                     <a href="{{ v }}">{{ v }}</a>
+                 {% elif k == 'nearest sha256' %}
+                     <a href="/file/{{ v }}">{{ v }}</a>
+                 {% elif k == 'task_id' %}
+                     <a href="http://localhost:8000/analysis/{{ v }}/summary">{{ v }}</a>
+                 {% else %}
+                     <pre>{{ v }}</pre>
+                 {% endif %}
+            </th>
         </tr>
         {% endif %}
         {% endfor %}

--- a/templates/file.html
+++ b/templates/file.html
@@ -10,7 +10,7 @@
                      <a href="{{ v }}">{{ v }}</a>
                  {% elif k == 'nearest sha256' %}
                      <a href="/file/{{ v }}">{{ v }}</a>
-                 {% elif k == 'task_id' %}
+                 {% elif k == 'task_id' and cuckoo %}
                      <a href="http://localhost:8000/analysis/{{ v }}/summary">{{ v }}</a>
                  {% else %}
                      <pre>{{ v }}</pre>


### PR DESCRIPTION
- Cuckoo APIを起動
- Cuckoo APIへ解析のリクエストを送信
- templates/file.htmlにおいて、task_idを表示
    - 表示したtask_idのリンク先をcuckoo webのsummaryに設定
