### PR TITLE
表層解析項目の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 venv
 PEiD
 trid
-build
+winchecksec
 __pycache__
 uploads
 pefiles

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv
 PEiD
 trid
+build
 __pycache__
 uploads
 pefiles

--- a/PEanalysis.py
+++ b/PEanalysis.py
@@ -18,7 +18,7 @@ HEADER = ['date', 'md5', 'sha1', 'sha256', 'ssdeep', 'imphash', 'impfuzzy',
           'peHashNG', 'Platform', 'GUI Program', 'Console Program', 'DLL',
           'Packed', 'Anti-Debug', 'mutex', 'contains base64',
           'AntiDebugMethod', 'PEiD', 'TrID', 'nearest sha256', 'nearest value',
-          'VTismalware', 'VirusTotalLink']
+          'VTismalware', 'VirusTotalLink', 'strings']
 IMPHEAD = ['date', 'sha256']
 
 
@@ -178,6 +178,11 @@ def analyse(filepath, pefiles_dir, pe, collection, useVT, api_key):
         ret_list.append('')
         ret_list.append('')
     
+    # strings
+    res = subprocess.check_output(['strings', filepath])
+    res = res.decode('utf-8')
+    ret_list.append(res)
+
     ret_dict = {}
     for i in range(0, len(HEADER)):
         ret_dict[HEADER[i]] = ret_list[i]

--- a/PEanalysis.py
+++ b/PEanalysis.py
@@ -12,15 +12,29 @@ import ssdeep
 import sys
 import json
 from virus_total_apis import PublicApi as VirusTotalPublicApi
+import platform
 
-HEADER = ['date', 'md5', 'sha1', 'sha256', 'ssdeep', 'imphash', 'impfuzzy',
-          'Totalhash', 'AnyMaster', 'AnyMaster_v1_0_1', 'EndGame', 'Crits',
-          'peHashNG', 'Platform', 'GUI Program', 'Console Program', 'DLL',
-          'Packed', 'Anti-Debug', 'mutex', 'contains base64',
-          'AntiDebugMethod', 'PEiD', 'TrID', 'nearest sha256', 'nearest value',
-          'VTismalware', 'VirusTotalLink', 'strings', 'import table', 
-          'export table']
-IMPHEAD = ['date', 'sha256']
+isUbuntu = 'Ubuntu' in platform.platform()
+if isUbuntu:
+    HEADER = ['date', 'md5', 'sha1', 'sha256', 'ssdeep', 'imphash', 'impfuzzy',
+              'Totalhash', 'AnyMaster', 'AnyMaster_v1_0_1', 'EndGame', 'Crits',
+              'peHashNG', 'Platform', 'GUI Program', 'Console Program', 'DLL',
+              'Packed', 'Anti-Debug', 'mutex', 'contains base64',
+              'AntiDebugMethod', 'PEiD', 'TrID', 'nearest sha256',
+              'nearest value', 'VTismalware', 'VirusTotalLink', 'strings', 
+              'import table', 'export table', 'Dynamic Base', 'ASLR', 
+              'High Entropy VA', 'Force Integrity', 'Isolation', 'NX', 'SEH', 
+              'CFG', 'RFG', 'SafeSEH', 'GS', 'Authenticode', 'dotNET']
+    IMPHEAD = ['date', 'sha256']
+else:
+    HEADER = ['date', 'md5', 'sha1', 'sha256', 'ssdeep', 'imphash', 'impfuzzy',
+              'Totalhash', 'AnyMaster', 'AnyMaster_v1_0_1', 'EndGame', 'Crits',
+              'peHashNG', 'Platform', 'GUI Program', 'Console Program', 'DLL',
+              'Packed', 'Anti-Debug', 'mutex', 'contains base64',
+              'AntiDebugMethod', 'PEiD', 'TrID', 'nearest sha256',
+              'nearest value', 'VTismalware', 'VirusTotalLink', 'strings', 
+              'import table', 'export table']
+    IMPHEAD = ['date', 'sha256']
 
 
 def prepare(pefiles_dir):
@@ -202,6 +216,38 @@ def analyse(filepath, pefiles_dir, pe, collection, useVT, api_key):
     else:
         exports_str = ''
     ret_list.append(exports_str)
+
+    # 'Dynamic Base', 'ASLR', 'High Entropy VA', 'Force Integrity', 
+    # 'Isolation', 'NX', 'SEH', 'CFG', 'RFG', 'SafeSEH', 'GS', 
+    # 'Authenticode', '.NET'
+    if isUbuntu:
+        cwd = os.getcwd()
+        os.chdir(cwd + '/winchecksec/build')
+        res = subprocess.check_output(['./winchecksec', filepath])
+        res = res.decode('utf-8').split('\n')
+        r = re.compile('([^:]+):\s\"([^"]+)\"')
+        res_dict = {}
+        for s in res:
+            m = r.match(s)
+            if m:
+                k = m.group(1).strip()
+                res_dict[k if k != '.NET' else 'dotNET'] = m.group(2)
+        
+        ret_list.append(res_dict['Dynamic Base'])
+        ret_list.append(res_dict['ASLR'])
+        ret_list.append(res_dict['High Entropy VA'])
+        ret_list.append(res_dict['Force Integrity'])
+        ret_list.append(res_dict['Isolation'])
+        ret_list.append(res_dict['NX'])
+        ret_list.append(res_dict['SEH'])
+        ret_list.append(res_dict['CFG'])
+        ret_list.append(res_dict['RFG'])
+        ret_list.append(res_dict['SafeSEH'])
+        ret_list.append(res_dict['GS'])
+        ret_list.append(res_dict['Authenticode'])
+        ret_list.append(res_dict['dotNET'])
+        
+        os.chdir(cwd)
 
     ret_dict = {}
     for i in range(0, len(HEADER)):

--- a/PEanalysis.py
+++ b/PEanalysis.py
@@ -18,7 +18,8 @@ HEADER = ['date', 'md5', 'sha1', 'sha256', 'ssdeep', 'imphash', 'impfuzzy',
           'peHashNG', 'Platform', 'GUI Program', 'Console Program', 'DLL',
           'Packed', 'Anti-Debug', 'mutex', 'contains base64',
           'AntiDebugMethod', 'PEiD', 'TrID', 'nearest sha256', 'nearest value',
-          'VTismalware', 'VirusTotalLink', 'strings']
+          'VTismalware', 'VirusTotalLink', 'strings', 'import table', 
+          'export table']
 IMPHEAD = ['date', 'sha256']
 
 
@@ -182,6 +183,25 @@ def analyse(filepath, pefiles_dir, pe, collection, useVT, api_key):
     res = subprocess.check_output(['strings', filepath])
     res = res.decode('utf-8')
     ret_list.append(res)
+
+    # import table
+    imports = []
+    for entry in pe.DIRECTORY_ENTRY_IMPORT:
+        for imp in entry.imports:
+            try:
+                imports.append(imp.name.decode('utf-8'))
+            except:
+                pass
+    imports_str = '\n'.join(imports)
+    ret_list.append(imports_str)
+
+    # export table
+    if hasattr(pe, 'DIRECTORY_ENTRY_EXPORT'):
+        exports = [s.name.decode('utf-8') for s in pe.DIRECTORY_ENTRY_EXPORT.symbols]
+        exports_str = '\n'.join(exports)
+    else:
+        exports_str = ''
+    ret_list.append(exports_str)
 
     ret_dict = {}
     for i in range(0, len(HEADER)):

--- a/app.py
+++ b/app.py
@@ -119,6 +119,28 @@ def render_strings(s256):
         return '不正なリクエストです。'
 
 
+@app.route('/imports/<s256>')
+def render_imports(s256):
+    result = collection.find_one({'sha256': s256})
+    if result:
+        return render_template('one_data.html', title='PEFile Surface Analyser - import table', 
+                one_data=result['import table'], 
+                cuckoo=app.config['cuckoo'])
+    else:
+        return '不正なリクエストです。'
+
+
+@app.route('/exports/<s256>')
+def render_exports(s256):
+    result = collection.find_one({'sha256': s256})
+    if result:
+        return render_template('one_data.html', title='PEFile Surface Analyser - export table', 
+                one_data=result['export table'], 
+                cuckoo=app.config['cuckoo'])
+    else:
+        return '不正なリクエストです。'
+
+
 @app.route('/file/<s256>')
 def render_file(s256):
     result = collection.find_one({'sha256': s256})

--- a/app.py
+++ b/app.py
@@ -101,9 +101,20 @@ def render_pefile(s256):
     if os.path.isfile(topath):
         with open(topath, 'r') as f:
             textdata = f.read()
-            return render_template('pefile.html', title='PEFile Surface Analyser - pefile', 
-                    textdata=textdata, 
+            return render_template('one_data.html', title='PEFile Surface Analyser - pefile', 
+                    one_data=textdata, 
                     cuckoo=app.config['cuckoo'])
+    else:
+        return '不正なリクエストです。'
+
+
+@app.route('/strings/<s256>')
+def render_strings(s256):
+    result = collection.find_one({'sha256': s256})
+    if result:
+        return render_template('one_data.html', title='PEFile Surface Analyser - strings', 
+                one_data=result['strings'], 
+                cuckoo=app.config['cuckoo'])
     else:
         return '不正なリクエストです。'
 

--- a/templates/file.html
+++ b/templates/file.html
@@ -13,7 +13,13 @@
                  {% elif k == 'nearest sha256' %}
                      <a href="/file/{{ v }}">{{ v }}</a>
                  {% elif k == 'strings' %}
-                     <a href="/strings/{{ file_dict['sha256'] }}">strings</a>
+		     <a href="/strings/{{ file_dict['sha256'] }}">{{ k }}</a>
+                 {% elif k == 'import table' %}
+		     <a href="/imports/{{ file_dict['sha256'] }}">{{ k }}</a>
+                 {% elif k == 'export table' %}
+		     {% if v != '' %}
+		         <a href="/exports/{{ file_dict['sha256'] }}">{{ k }}</a>
+		     {% endif %}
 		 {% elif k == 'task_id' and cuckoo %}
                      <a href="http://localhost:8000/analysis/{{ v }}/summary">{{ v }}</a>
                  {% else %}

--- a/templates/file.html
+++ b/templates/file.html
@@ -12,7 +12,9 @@
                      <a href="{{ v }}">{{ v }}</a>
                  {% elif k == 'nearest sha256' %}
                      <a href="/file/{{ v }}">{{ v }}</a>
-                 {% elif k == 'task_id' and cuckoo %}
+                 {% elif k == 'strings' %}
+                     <a href="/strings/{{ file_dict['sha256'] }}">strings</a>
+		 {% elif k == 'task_id' and cuckoo %}
                      <a href="http://localhost:8000/analysis/{{ v }}/summary">{{ v }}</a>
                  {% else %}
                      <pre>{{ v }}</pre>

--- a/templates/one_data.html
+++ b/templates/one_data.html
@@ -1,4 +1,4 @@
 {% extends "layout.html" %}
 {% block body_content %}
-<pre>{{ textdata }}</pre>
+<pre>{{ one_data }}</pre>
 {% endblock %}


### PR DESCRIPTION
- stringsコマンドの結果を追加
- pefileのimport table、export tableのimport/export nameのみを追加
- winchecksecの結果を追加(Ubuntu18.04のみ)

Ubuntu18.04/CentOS7のそれぞれで期待通りの動作することを確認しました。特に、winchecksec関連の項目はUbuntuの時のみ表示されることを確認しました。